### PR TITLE
reenable invalid type check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-CXXFLAGS=-Werror -Wall -g
-
-jsonxx_test: jsonxx_test.cc jsonxx.o
+CXXFLAGS=-std=c++11 -Werror -Wall -g -DDEBUG
 
 jsonxx.o: jsonxx.h jsonxx.cc
 
-test: jsonxx_test
+jsonxx_test: CXXFLAGS+=-Wno-error=deprecated-declarations
+jsonxx_test: jsonxx_test.cc jsonxx.o
+
+test: jsonxx.o jsonxx_test
 	./jsonxx_test
 
 .PHONY: clean

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -195,6 +195,16 @@ namespace jsonxx {
         ~Value() { reset(); }
         void reset();
 
+        template<typename T>
+        [[deprecated("this type is not natively supported by jsonxx, therefore its value will be converted to 'null'")]]
+        void import( const T& t ) {
+            reset();
+            type_ = INVALID_;
+#ifdef DEBUG
+            std::cerr << "[WARN] No JSONXX support for " << typeid(t).name() << std::endl;
+#endif
+        }
+
         void import( const bool &b ) {
             reset();
             type_ = BOOL_;

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -195,6 +195,7 @@ namespace jsonxx {
         ~Value() { reset(); }
         void reset();
 
+#ifdef JSONXX_ALLOW_INVALID_TYPES
         template<typename T>
         [[deprecated("this type is not natively supported by jsonxx, therefore its value will be converted to 'null'")]]
         void import( const T& t ) {
@@ -204,6 +205,9 @@ namespace jsonxx {
             std::cerr << "[WARN] No JSONXX support for " << typeid(t).name() << std::endl;
 #endif
         }
+#else
+        template<typename T> void import( const T& t ) = delete;
+#endif
 
         void import( const bool &b ) {
             reset();

--- a/jsonxx_test.cc
+++ b/jsonxx_test.cc
@@ -560,7 +560,7 @@ int main(int argc, const char **argv) {
         o << "number" << 123;
         o << "string" << "hello world";
         o << "boolean" << false;
-        o << "null" << static_cast<void*>(0);
+        o << "null" << nullptr;
         o << "array" << a;
         o << "object" << jsonxx::Object("child", "object");
         o << "undefined" << custom_type();

--- a/jsonxx_test.cc
+++ b/jsonxx_test.cc
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <fstream>
 
+#define JSONXX_ALLOW_INVALID_TYPES
 #include "jsonxx.h"
 
 namespace jsonxx {


### PR DESCRIPTION
without this check, invalid types cause an infinite recursion instead of a
warning and a null being serialized