### PR TITLE
handle infinite numeric values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ jsonxx.o: jsonxx.h jsonxx.cc
 jsonxx_test: CXXFLAGS+=-Wno-error=deprecated-declarations
 jsonxx_test: jsonxx_test.cc jsonxx.o
 
+.PHONY:
 test: jsonxx.o jsonxx_test
 	./jsonxx_test
 

--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -192,19 +192,21 @@ bool parse_number(std::istream& input, Number& value) {
         if (parse_number_inf(input, value, rollback)) {
             return true;
         }
+
         input.clear();
         input.seekg(rollback);
         return false;
     }
-    else {
-        if (value >= MaxNumberRange) {
-            value = std::numeric_limits<Number>::infinity();
-        }
-        else if (value <= MinNumberRange) {
-            value = -std::numeric_limits<Number>::infinity();
-        }
-        return true;
+
+#if !JSONXX_FORBID_INFINITY
+    if (value >= MaxNumberRange) {
+        value = std::numeric_limits<Number>::infinity();
     }
+    else if (value <= MinNumberRange) {
+        value = -std::numeric_limits<Number>::infinity();
+    }
+#endif
+    return true;
 }
 
 bool parse_number_inf(std::istream& input, Number& value, std::streampos rollback) {
@@ -229,11 +231,11 @@ bool parse_number_inf(std::istream& input, Number& value, std::streampos rollbac
     do {
         ch = input.get();
     } while (isdigit(ch));
-    
+
     if (ch != 'E' && ch != 'e') {
         return false;
     }
-    
+
     int exponent;
     input >> exponent;
     return !input.fail();

--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -14,6 +14,7 @@
 #include <vector>
 #include <limits>
 #include <mutex>
+#include <math.h>
 
 // Snippet that creates an assertion function that works both in DEBUG & RELEASE mode.
 // JSONXX_ASSERT(...) macro will redirect to this. assert() macro is kept untouched.
@@ -46,6 +47,7 @@ bool parse_bool(std::istream& input, Boolean& value);
 bool parse_comment(std::istream &input);
 bool parse_null(std::istream& input);
 bool parse_number(std::istream& input, Number& value);
+bool parse_number_inf(std::istream& input, Number& value, std::streampos rollback);
 bool parse_object(std::istream& input, Object& object);
 bool parse_string(std::istream& input, String& value);
 bool parse_identifier(std::istream& input, String& value);
@@ -187,11 +189,54 @@ bool parse_number(std::istream& input, Number& value) {
     std::streampos rollback = input.tellg();
     input >> value;
     if (input.fail()) {
+        if (parse_number_inf(input, value, rollback)) {
+            return true;
+        }
         input.clear();
         input.seekg(rollback);
         return false;
     }
-    return true;
+    else {
+        if (value >= MaxNumberRange) {
+            value = std::numeric_limits<Number>::infinity();
+        }
+        else if (value <= MinNumberRange) {
+            value = -std::numeric_limits<Number>::infinity();
+        }
+        return true;
+    }
+}
+
+bool parse_number_inf(std::istream& input, Number& value, std::streampos rollback) {
+    input.clear();
+    input.seekg(rollback);
+
+    switch (input.peek()) {
+        case '-':
+            input.get();
+            value = -std::numeric_limits<Number>::infinity();
+            break;
+        case '+':
+        case '0'...'9':
+            input.get();
+            value = std::numeric_limits<Number>::infinity();
+            break;
+        default:
+            return false;
+    }
+
+    int ch;
+    do {
+        ch = input.get();
+    } while (isdigit(ch));
+    
+    if (ch != 'E' && ch != 'e') {
+        return false;
+    }
+    
+    int exponent;
+    input >> exponent;
+    return !input.fail();
 }
 
 bool parse_bool(std::istream& input, Boolean& value) {
@@ -599,9 +644,23 @@ namespace json {
                 return remove_last_comma( ss.str() ) + tab + "}" ",\n";
 
             case jsonxx::Value::NUMBER_:
-                // max precision
-                ss << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
-                ss << t.number_value_;
+                if (isfinite(t.number_value_)) {
+                    // max precision
+                    ss << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
+                    ss << t.number_value_;
+                }
+#if !JSONXX_FORBID_INFINITY
+                else if (t.number_value_ > MaxNumberRange) {
+                    ss << InfinityRepresentation;
+                }
+                else if (t.number_value_ < MinNumberRange) {
+                    ss << '-' << InfinityRepresentation;
+                }
+#endif
+                else {
+                    JSONXX_WARN( "No JSONXX support for number value " << t.number_value_ );
+                    ss << "null"; // NaN or other stuff we cannot represent
+                }
                 return ss.str() + ",\n";
         }
     }

--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -198,7 +198,7 @@ bool parse_number(std::istream& input, Number& value) {
         return false;
     }
 
-#if !JSONXX_FORBID_INFINITY
+#if JSONXX_HANDLE_INFINITY
     if (value >= MaxNumberRange) {
         value = std::numeric_limits<Number>::infinity();
     }
@@ -651,7 +651,7 @@ namespace json {
                     ss << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
                     ss << t.number_value_;
                 }
-#if !JSONXX_FORBID_INFINITY
+#if JSONXX_HANDLE_INFINITY
                 else if (t.number_value_ > MaxNumberRange) {
                     ss << InfinityRepresentation;
                 }

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -39,6 +39,10 @@
 #define JSONXX_ASSERT(...) do { if( jsonxx::Assertions ) \
   jsonxx::assertion(__FILE__,__LINE__,#__VA_ARGS__,bool(__VA_ARGS__)); } while(0)
 
+#ifndef JSONXX_HANDLE_INFINITY
+#define JSONXX_HANDLE_INFINITY 1
+#endif
+
 #ifdef DEBUG
 #define JSONXX_WARN(...) \
   std::cerr << "[WARN] " << __VA_ARGS__ << std::endl;

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cassert>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <vector>
 #include <string>
@@ -37,6 +38,13 @@
 
 #define JSONXX_ASSERT(...) do { if( jsonxx::Assertions ) \
   jsonxx::assertion(__FILE__,__LINE__,#__VA_ARGS__,bool(__VA_ARGS__)); } while(0)
+
+#ifdef DEBUG
+#define JSONXX_WARN(...) \
+  std::cerr << "[WARN] " << __VA_ARGS__ << std::endl;
+#else
+#define JSONXX_WARN(...) ;
+#endif
 
 namespace jsonxx {
     
@@ -74,6 +82,13 @@ namespace jsonxx {
     class Value;
     class Object;
     class Array;
+    
+    // Range of Number. Valid numbers outside the range as considered infinite
+    constexpr Number MaxNumberRange = std::numeric_limits<double>::max();
+    constexpr Number MinNumberRange = -std::numeric_limits<double>::max();
+    
+    // JSON representation of infinite numbers
+    constexpr const char* InfinityRepresentation = "1e500";
     
     // Identity meta-function
     template <typename T>
@@ -201,9 +216,7 @@ namespace jsonxx {
         void import( const T& t ) {
             reset();
             type_ = INVALID_;
-#ifdef DEBUG
-            std::cerr << "[WARN] No JSONXX support for " << typeid(t).name() << std::endl;
-#endif
+            JSONXX_WARN( "No JSONXX support for " << typeid(t).name() );
         }
 #else
         template<typename T> void import( const T& t ) = delete;

--- a/jsonxx_test.cc
+++ b/jsonxx_test.cc
@@ -653,7 +653,7 @@ int main(int argc, const char **argv) {
         TEST( value < 0 );
         TEST( isinf(value) );
 
-#if !JSONXX_FORBID_INFINITY
+#if JSONXX_HANDLE_INFINITY
         value = o.get<jsonxx::Number>("pos");
         TEST( value > 0 );
         TEST( isinf(value) );
@@ -666,10 +666,10 @@ int main(int argc, const char **argv) {
 
     {
         // infinity serialization test
-#if JSONXX_FORBID_INFINITY
-        string expected(R"( { "neg": null, "pos": null } )");
-#else
+#if JSONXX_HANDLE_INFINITY
         string expected(R"( { "neg": -1e500, "pos": 1e500 } )");
+#else
+        string expected(R"( { "neg": null, "pos": null } )");
 #endif
 
         jsonxx::Object o;

--- a/jsonxx_test.cc
+++ b/jsonxx_test.cc
@@ -641,13 +641,9 @@ int main(int argc, const char **argv) {
         jsonxx::Object o;
         TEST( o.parse(teststr) );
 
-        auto value = o.get<jsonxx::Number>("pos");
+        auto value = o.get<jsonxx::Number>("finite");
         TEST( value > 0 );
-        TEST( isinf(value) );
-
-        value = o.get<jsonxx::Number>("neg");
-        TEST( value < 0 );
-        TEST( isinf(value) );
+        TEST( isfinite(value) );
 
         value = o.get<jsonxx::Number>("pos_overflow");
         TEST( value > 0 );
@@ -657,9 +653,15 @@ int main(int argc, const char **argv) {
         TEST( value < 0 );
         TEST( isinf(value) );
 
-        value = o.get<jsonxx::Number>("finite");
+#if !JSONXX_FORBID_INFINITY
+        value = o.get<jsonxx::Number>("pos");
         TEST( value > 0 );
-        TEST( isfinite(value) );
+        TEST( isinf(value) );
+
+        value = o.get<jsonxx::Number>("neg");
+        TEST( value < 0 );
+        TEST( isinf(value) );
+#endif
     }
 
     {


### PR DESCRIPTION
Since JSON doesn't have any standard representations for infinity, which is a valid (and quite common) value for C++ floating point numbers, we'd better work around this restriction in a consistent and automatic manner rather than increase the cognitive load of the programmers.

These changes improve the behaviour of JSONXX by:
* considering numbers too large for a `long double` as infinite values (like other JS parsers)
* serializing `NaN` as `null` and displaying a warning

If `JSONXX_HANDLE_INFINITY` is set to a value that evaluates to `true` (or if the macro is left undefined), then:
1. the behaviour of the parser is more consistent with other JavaScript parsers: large numeric values (> 1e108) are considered as infinite.
2. infinite numbers are serialized as a very large number (see `InfinityRepresentation`).

Otherwise:
1. large numeric values are considered finite (current JSONXX behaviour);
2. infinite numbers are serialized as `null` and a warning is displayed on the standard error output in debug mode. This is also an improvement on the current behaviour, which produces invalid JSONs by serializing those values as `inf`.