### PR TITLE
Add floatPrecision paramters to serializer functions

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -610,7 +610,7 @@ namespace json {
         return input;
     }
 
-    std::string tag( unsigned format, unsigned depth, const std::string &name, const jsonxx::Value &t, PrintMode printMode, int floatPrecision = std::numeric_limits<long double>::digits10 + 1) {
+    std::string tag( unsigned format, unsigned depth, const std::string &name, const jsonxx::Value &t, PrintMode printMode, int floatPrecision = std::numeric_limits<double>::digits10 + 1) {
         std::stringstream ss;
         std::string tab(depth, '\t');
         std::string newLine("\n");
@@ -827,7 +827,7 @@ std::string close_tag( unsigned format, char type, const std::string &name ) {
     }
 }
 
-std::string tag( unsigned format, unsigned depth, const std::string &name, const jsonxx::Value &t, const std::string &attr = std::string(), int floatPrecision = std::numeric_limits<long double>::digits10 + 1) {
+std::string tag( unsigned format, unsigned depth, const std::string &name, const jsonxx::Value &t, const std::string &attr = std::string(), int floatPrecision = std::numeric_limits<double>::digits10 + 1) {
     std::stringstream ss;
     const std::string tab(depth, '\t');
 

--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -679,7 +679,6 @@ namespace json {
                     ss << "null"; // NaN or other stuff we cannot represent
                 }
                 
-                ss << std::setprecision(floatPrecision);
                 return ss.str() + "," + newLine;
         }
     }

--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -610,7 +610,7 @@ namespace json {
         return input;
     }
 
-    std::string tag( unsigned format, unsigned depth, const std::string &name, const jsonxx::Value &t, PrintMode printMode) {
+    std::string tag( unsigned format, unsigned depth, const std::string &name, const jsonxx::Value &t, PrintMode printMode, int floatPrecision = std::numeric_limits<long double>::digits10 + 1) {
         std::stringstream ss;
         std::string tab(depth, '\t');
         std::string newLine("\n");
@@ -646,7 +646,7 @@ namespace json {
                 ss << "[" + newLine;
                 for(Array::container::const_iterator it = t.array_value_->values().begin(),
                     end = t.array_value_->values().end(); it != end; ++it )
-                  ss << tag( format, depth+1, std::string(), **it, printMode );
+                  ss << tag( format, depth+1, std::string(), **it, printMode, floatPrecision );
                 return remove_last_comma( ss.str() ) + tab + "]" "," + newLine;
 
             case jsonxx::Value::STRING_:
@@ -657,13 +657,13 @@ namespace json {
                 ss << "{" + newLine;
                 for(Object::container::const_iterator it=t.object_value_->kv_map().begin(),
                     end = t.object_value_->kv_map().end(); it != end ; ++it)
-                  ss << tag( format, depth+1, it->first, *it->second, printMode );
+                  ss << tag( format, depth+1, it->first, *it->second, printMode, floatPrecision);
                 return remove_last_comma( ss.str() ) + tab + "}" "," + newLine;
 
             case jsonxx::Value::NUMBER_:
                 if (isfinite(t.number_value_)) {
                     // max precision
-                    ss << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
+                    ss << std::setprecision(floatPrecision);
                     ss << t.number_value_;
                 }
 #if JSONXX_HANDLE_INFINITY
@@ -678,6 +678,8 @@ namespace json {
                     JSONXX_WARN( "No JSONXX support for number value " << t.number_value_ );
                     ss << "null"; // NaN or other stuff we cannot represent
                 }
+                
+                ss << std::setprecision(floatPrecision);
                 return ss.str() + "," + newLine;
         }
     }
@@ -825,7 +827,7 @@ std::string close_tag( unsigned format, char type, const std::string &name ) {
     }
 }
 
-std::string tag( unsigned format, unsigned depth, const std::string &name, const jsonxx::Value &t, const std::string &attr = std::string() ) {
+std::string tag( unsigned format, unsigned depth, const std::string &name, const jsonxx::Value &t, const std::string &attr = std::string(), int floatPrecision = std::numeric_limits<long double>::digits10 + 1) {
     std::stringstream ss;
     const std::string tab(depth, '\t');
 
@@ -844,7 +846,7 @@ std::string tag( unsigned format, unsigned depth, const std::string &name, const
         case jsonxx::Value::ARRAY_:
             for(Array::container::const_iterator it = t.array_value_->values().begin(),
                 end = t.array_value_->values().end(); it != end; ++it )
-              ss << tag( format, depth+1, std::string(), **it );
+              ss << tag( format, depth+1, std::string(), **it, std::string(), floatPrecision );
             return tab + open_tag( format, 'a', name, attr ) + '\n'
                        + ss.str()
                  + tab + close_tag( format, 'a', name ) + '\n';
@@ -858,14 +860,14 @@ std::string tag( unsigned format, unsigned depth, const std::string &name, const
         case jsonxx::Value::OBJECT_:
             for(Object::container::const_iterator it=t.object_value_->kv_map().begin(),
                 end = t.object_value_->kv_map().end(); it != end ; ++it)
-              ss << tag( format, depth+1, it->first, *it->second );
+              ss << tag( format, depth+1, it->first, *it->second, std::string(), floatPrecision );
             return tab + open_tag( format, 'o', name, attr ) + '\n'
                        + ss.str()
                  + tab + close_tag( format, 'o', name ) + '\n';
 
         case jsonxx::Value::NUMBER_:
             // max precision
-            ss << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
+            ss << std::setprecision(floatPrecision);
             ss << t.number_value_;
             return tab + open_tag( format, 'n', name, std::string(), format == jsonxx::JXMLex ? ss.str() : std::string() )
                        + ss.str()
@@ -909,20 +911,20 @@ const char *defrootattrib[] = {
 
 } // namespace jsonxx::anon
 
-std::string Object::json(PrintMode printMode) const {
+std::string Object::json(PrintMode printMode, int floatPrecision) const {
     using namespace json;
 
     jsonxx::Value v;
     v.object_value_ = const_cast<jsonxx::Object*>(this);
     v.type_ = jsonxx::Value::OBJECT_;
 
-    std::string result = tag( jsonxx::JSON, 0, std::string(), v, printMode );
+    std::string result = tag( jsonxx::JSON, 0, std::string(), v, printMode, floatPrecision );
 
     v.object_value_ = 0;
     return remove_last_comma( result );
 }
 
-std::string Object::xml( unsigned format, const std::string &header, const std::string &attrib ) const {
+std::string Object::xml( unsigned format, const std::string &header, const std::string &attrib, int floatPrecision ) const {
     using namespace xml;
     JSONXX_ASSERT( format == jsonxx::JSONx || format == jsonxx::JXML || format == jsonxx::JXMLex || format == jsonxx::TaggedXML );
 
@@ -930,26 +932,26 @@ std::string Object::xml( unsigned format, const std::string &header, const std::
     v.object_value_ = const_cast<jsonxx::Object*>(this);
     v.type_ = jsonxx::Value::OBJECT_;
 
-    std::string result = tag( format, 0, std::string(), v, attrib.empty() ? std::string(defrootattrib[format]) : attrib );
+    std::string result = tag( format, 0, std::string(), v, attrib.empty() ? std::string(defrootattrib[format]) : attrib, floatPrecision );
 
     v.object_value_ = 0;
     return ( header.empty() ? std::string(defheader[format]) : header ) + result;
 }
 
-std::string Array::json(PrintMode printMode) const {
+std::string Array::json(PrintMode printMode, int floatPrecision) const {
     using namespace json;
 
     jsonxx::Value v;
     v.array_value_ = const_cast<jsonxx::Array*>(this);
     v.type_ = jsonxx::Value::ARRAY_;
 
-    std::string result = tag( jsonxx::JSON, 0, std::string(), v, printMode );
+    std::string result = tag( jsonxx::JSON, 0, std::string(), v, printMode, floatPrecision);
 
     v.array_value_ = 0;
     return remove_last_comma( result );
 }
 
-std::string Array::xml( unsigned format, const std::string &header, const std::string &attrib ) const {
+std::string Array::xml( unsigned format, const std::string &header, const std::string &attrib, int floatPrecision ) const {
     using namespace xml;
     JSONXX_ASSERT( format == jsonxx::JSONx || format == jsonxx::JXML || format == jsonxx::JXMLex || format == jsonxx::TaggedXML );
 
@@ -957,7 +959,7 @@ std::string Array::xml( unsigned format, const std::string &header, const std::s
     v.array_value_ = const_cast<jsonxx::Array*>(this);
     v.type_ = jsonxx::Value::ARRAY_;
 
-    std::string result = tag( format, 0, std::string(), v, attrib.empty() ? std::string(defrootattrib[format]) : attrib );
+    std::string result = tag( format, 0, std::string(), v, attrib.empty() ? std::string(defrootattrib[format]) : attrib, floatPrecision );
 
     v.array_value_ = 0;
     return ( header.empty() ? std::string(defheader[format]) : header ) + result;

--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -678,7 +678,6 @@ namespace json {
                     JSONXX_WARN( "No JSONXX support for number value " << t.number_value_ );
                     ss << "null"; // NaN or other stuff we cannot represent
                 }
-                
                 return ss.str() + "," + newLine;
         }
     }

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -139,8 +139,8 @@ namespace jsonxx {
         bool empty() const;
         
         const std::map<std::string, Value*>& kv_map() const;
-        std::string json(PrintMode printMode = PrintMode::Compact) const;
-        std::string xml( unsigned format = JSONx, const std::string &header = std::string(), const std::string &attrib = std::string() ) const;
+        std::string json(PrintMode printMode = PrintMode::Compact, int floatPrecision = std::numeric_limits<long double>::digits10 + 1) const;
+        std::string xml( unsigned format = JSONx, const std::string &header = std::string(), const std::string &attrib = std::string(), int floatPrecision = std::numeric_limits<long double>::digits10 + 1) const;
         std::string write( unsigned format ) const;
         
         void reset();
@@ -189,8 +189,8 @@ namespace jsonxx {
         const std::vector<Value*>& values() const {
             return values_;
         }
-        std::string json(PrintMode printMode = PrintMode::Compact) const;
-        std::string xml( unsigned format = JSONx, const std::string &header = std::string(), const std::string &attrib = std::string() ) const;
+        std::string json(PrintMode printMode = PrintMode::Compact, int floatPrecision = std::numeric_limits<long double>::digits10 + 1) const;
+        std::string xml( unsigned format = JSONx, const std::string &header = std::string(), const std::string &attrib = std::string(), int floatPrecision = std::numeric_limits<long double>::digits10 + 1) const;
         
         std::string write( unsigned format ) const { return format == JSON ? json() : xml(format); }
         void reset();

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -139,8 +139,8 @@ namespace jsonxx {
         bool empty() const;
         
         const std::map<std::string, Value*>& kv_map() const;
-        std::string json(PrintMode printMode = PrintMode::Compact, int floatPrecision = std::numeric_limits<long double>::digits10 + 1) const;
-        std::string xml( unsigned format = JSONx, const std::string &header = std::string(), const std::string &attrib = std::string(), int floatPrecision = std::numeric_limits<long double>::digits10 + 1) const;
+        std::string json(PrintMode printMode = PrintMode::Compact, int floatPrecision = std::numeric_limits<double>::digits10 + 1) const;
+        std::string xml( unsigned format = JSONx, const std::string &header = std::string(), const std::string &attrib = std::string(), int floatPrecision = std::numeric_limits<double>::digits10 + 1) const;
         std::string write( unsigned format ) const;
         
         void reset();
@@ -189,8 +189,8 @@ namespace jsonxx {
         const std::vector<Value*>& values() const {
             return values_;
         }
-        std::string json(PrintMode printMode = PrintMode::Compact, int floatPrecision = std::numeric_limits<long double>::digits10 + 1) const;
-        std::string xml( unsigned format = JSONx, const std::string &header = std::string(), const std::string &attrib = std::string(), int floatPrecision = std::numeric_limits<long double>::digits10 + 1) const;
+        std::string json(PrintMode printMode = PrintMode::Compact, int floatPrecision = std::numeric_limits<double>::digits10 + 1) const;
+        std::string xml( unsigned format = JSONx, const std::string &header = std::string(), const std::string &attrib = std::string(), int floatPrecision = std::numeric_limits<double>::digits10 + 1) const;
         
         std::string write( unsigned format ) const { return format == JSON ? json() : xml(format); }
         void reset();


### PR DESCRIPTION
The `std::numeric_limits<long double>::digits10` value differs on Intel Mac and M1 Mac, which causes some geojson serialization tests to fail. 

I added a `int floatPrecision` parameters to `.json()` functions in order to be able to control the precision of serialized double.

Also, use `double` instead of `long double` to avoid back and forth between tests passing locally but failing on CI if you forget to set the precision manually, since `std::numeric_limits<double>::digits10` evaluates to the same value on both platforms (in contrary to `long double`). 
