### PR TITLE
Delete get functions with rvalue as default parameter

### DIFF
--- a/jsonxx.h
+++ b/jsonxx.h
@@ -98,6 +98,9 @@ namespace jsonxx {
     
     // JSON representation of infinite numbers
     constexpr const char* InfinityRepresentation = "1e500";
+
+    // Default value
+    static const String EmptyString = "";
     
     // Identity meta-function
     template <typename T>
@@ -135,6 +138,13 @@ namespace jsonxx {
         template <typename T>
         const T& get(const std::string& key, const typename identity<T>::type& default_value) const;
         
+        // Delete unsafe operation
+        template <typename T>
+        const T& get(const std::string& key, typename identity<jsonxx::Object>::type&& default_value) = delete;
+        
+        template <typename T>
+        const T& get(const std::string& key, typename identity<jsonxx::String>::type&& default_value) = delete;
+
         size_t size() const;
         bool empty() const;
         
@@ -167,6 +177,8 @@ namespace jsonxx {
         std::string odd;
     };
     
+    static const Object EmptyObject = {};
+    
     class Array {
     public:
         Array();
@@ -186,6 +198,13 @@ namespace jsonxx {
         template <typename T>
         const T& get(unsigned int i, const typename identity<T>::type& default_value) const;
         
+        // Delete unsafe operation
+        template <typename T>
+        const T& get(unsigned int i, typename identity<jsonxx::String>::type&& default_value) = delete;
+        
+        template <typename T>
+        const T& get(unsigned int i, typename identity<jsonxx::Object>::type&& default_value) = delete;
+
         const std::vector<Value*>& values() const {
             return values_;
         }
@@ -209,6 +228,8 @@ namespace jsonxx {
         static bool parse(std::istream& input, Array& array);
         container values_;
     };
+
+    static const Array EmptyArray = {};
     
     // A value could be a number, an array, a string, an object, a
     // boolean, or null

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -104,6 +104,8 @@ namespace jsonxx {
     static const Number Zero = 0;
     static const Number MinusOne = -1;
     static const Number One = 1;
+    static const Boolean True = true;
+    static const Boolean False = false;
 
     // Identity meta-function
     template <typename T>
@@ -388,7 +390,9 @@ number_value_ = static_cast<long double>(n); \
     protected:
         static bool parse(std::istream& input, Value& value);
     };
-    
+
+    static const Value EmptyValue = {};
+
     template <typename T>
     bool Array::has(unsigned int i) const {
         if (i >= size()) {
@@ -562,11 +566,6 @@ number_value_ = static_cast<long double>(n); \
         *this << Value(value);
         return *this;
     }
-
-    static const Value EmptyValue = {};
-
-    static const Boolean True = true;
-    static const Boolean False = false;
 }  // namespace jsonxx
 
 std::ostream& operator<<(std::ostream& stream, const jsonxx::Value& v);

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -101,7 +101,8 @@ namespace jsonxx {
 
     // Default value
     static const String EmptyString = "";
-    
+    static const Number Zero = 0;
+
     // Identity meta-function
     template <typename T>
     struct identity {
@@ -140,10 +141,7 @@ namespace jsonxx {
         
         // Delete unsafe operation
         template <typename T>
-        const T& get(const std::string& key, typename identity<jsonxx::Object>::type&& default_value) = delete;
-        
-        template <typename T>
-        const T& get(const std::string& key, typename identity<jsonxx::String>::type&& default_value) = delete;
+        const T& get(const std::string& key, typename identity<T>::type&& default_value) = delete;
 
         size_t size() const;
         bool empty() const;
@@ -200,10 +198,7 @@ namespace jsonxx {
         
         // Delete unsafe operation
         template <typename T>
-        const T& get(unsigned int i, typename identity<jsonxx::String>::type&& default_value) = delete;
-        
-        template <typename T>
-        const T& get(unsigned int i, typename identity<jsonxx::Object>::type&& default_value) = delete;
+        const T& get(unsigned int i, typename identity<T>::type&& default_value) = delete;
 
         const std::vector<Value*>& values() const {
             return values_;
@@ -565,7 +560,10 @@ number_value_ = static_cast<long double>(n); \
         *this << Value(value);
         return *this;
     }
-    
+
+    static const jsonxx::Boolean True = true;
+    static const jsonxx::Boolean False = false;
+
 }  // namespace jsonxx
 
 std::ostream& operator<<(std::ostream& stream, const jsonxx::Value& v);

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -101,7 +101,10 @@ namespace jsonxx {
 
     // Default value
     static const String EmptyString = "";
-    
+    static const Number Zero = 0;
+    static const Number MinusOne = -1;
+    static const Number One = 1;
+
     // Identity meta-function
     template <typename T>
     struct identity {
@@ -134,16 +137,13 @@ namespace jsonxx {
         T& get(const std::string& key);
         template <typename T>
         const T& get(const std::string& key) const;
-        
+ 
         template <typename T>
         const T& get(const std::string& key, const typename identity<T>::type& default_value) const;
-        
+    
         // Delete unsafe operation
         template <typename T>
-        const T& get(const std::string& key, typename identity<jsonxx::Object>::type&& default_value) = delete;
-        
-        template <typename T>
-        const T& get(const std::string& key, typename identity<jsonxx::String>::type&& default_value) = delete;
+        const T& get(const std::string& key, typename identity<T>::type&& default_value) const = delete;
 
         size_t size() const;
         bool empty() const;
@@ -200,10 +200,7 @@ namespace jsonxx {
         
         // Delete unsafe operation
         template <typename T>
-        const T& get(unsigned int i, typename identity<jsonxx::String>::type&& default_value) = delete;
-        
-        template <typename T>
-        const T& get(unsigned int i, typename identity<jsonxx::Object>::type&& default_value) = delete;
+        const T& get(unsigned int i, typename identity<T>::type&& default_value) const = delete;
 
         const std::vector<Value*>& values() const {
             return values_;
@@ -565,7 +562,11 @@ number_value_ = static_cast<long double>(n); \
         *this << Value(value);
         return *this;
     }
-    
+
+    static const Value EmptyValue = {};
+
+    static const Boolean True = true;
+    static const Boolean False = false;
 }  // namespace jsonxx
 
 std::ostream& operator<<(std::ostream& stream, const jsonxx::Value& v);

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -102,11 +102,8 @@ namespace jsonxx {
     // Default value
     static const String EmptyString = "";
     static const Number Zero = 0;
-<<<<<<< HEAD
     static const Number MinusOne = -1;
     static const Number One = 1;
-=======
->>>>>>> c47bf6f88390ab84adc2fc02f5473ef8de5c5c60
 
     // Identity meta-function
     template <typename T>


### PR DESCRIPTION
Delete get functions with rvalue as default parameter to prevent storing reference to out of scope data.

Also add a bunch of `static const` definition to simplify to refactor in transitlib (https://github.com/TransitApp/transitLib/pull/5586). 