### PR TITLE
declare Value constructor only for known types

### DIFF
--- a/jsonxx.h
+++ b/jsonxx.h
@@ -353,8 +353,34 @@ number_value_ = static_cast<long double>(n); \
         }
         Value(const Value &other);
 
-        template<typename T, typename = typename std::enable_if<std::is_same<decltype(&Value::import<T>), void>::value>::type>
+#ifdef JSONXX_ALLOW_INVALID_TYPES
+        template<typename T>
         Value( const T&t ) : type_(INVALID_) { import(t); }
+#else
+#define $Value(TYPE) Value( const TYPE &t ) : type_(INVALID_) { import(t); }
+        $Value( bool )
+        $Value( char )
+        $Value( int )
+        $Value( long )
+        $Value( long long )
+        $Value( unsigned char )
+        $Value( unsigned int )
+        $Value( unsigned long )
+        $Value( unsigned long long )
+        $Value( float )
+        $Value( double )
+        $Value( long double )
+#if JSONXX_COMPILER_HAS_CXX11 > 0
+        $Value( std::nullptr_t )
+#endif
+        $Value( Null )
+        $Value( String )
+        $Value( std::string_view )
+        template<typename T> $Value( std::vector<T> )
+        $Value( Array )
+        $Value( Object )
+#undef $Value
+#endif
 
         template<size_t N>
         Value( const char (&t)[N] ) : type_(INVALID_) { import( std::string(t) ); }

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -352,8 +352,10 @@ number_value_ = static_cast<long double>(n); \
             return *this;
         }
         Value(const Value &other);
-        template<typename T>
+
+        template<typename T, typename = typename std::enable_if<std::is_same<decltype(&Value::import<T>), void>::value>::type>
         Value( const T&t ) : type_(INVALID_) { import(t); }
+
         template<size_t N>
         Value( const char (&t)[N] ) : type_(INVALID_) { import( std::string(t) ); }
         

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -353,11 +353,11 @@ number_value_ = static_cast<long double>(n); \
         }
         Value(const Value &other);
 
-#ifdef JSONXX_ALLOW_INVALID_TYPES
-        template<typename T>
-        Value( const T&t ) : type_(INVALID_) { import(t); }
-#else
 #define $Value(TYPE) Value( const TYPE &t ) : type_(INVALID_) { import(t); }
+
+#ifdef JSONXX_ALLOW_INVALID_TYPES
+        template<typename T> $Value( T )
+#else
         $Value( bool )
         $Value( char )
         $Value( int )
@@ -379,8 +379,9 @@ number_value_ = static_cast<long double>(n); \
         template<typename T> $Value( std::vector<T> )
         $Value( Array )
         $Value( Object )
-#undef $Value
 #endif
+
+#undef $Value
 
         template<size_t N>
         Value( const char (&t)[N] ) : type_(INVALID_) { import( std::string(t) ); }


### PR DESCRIPTION
There's an ambiguity in how the Value constructor is defined, which causes `operator<<(ostream&, T)` to ambiguously match with `operator<<(ostream&, jsonxx::Value&)` and other definitions of `operator<<`, resulting in a compilation error.