### PR TITLE
Includes clean up: cassert is only used in the cpp file

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -8,6 +8,7 @@
 #include "jsonxx.h"
 
 #include <cctype>
+#include <cassert>
 #include <iostream>
 #include <iomanip>
 #include <sstream>

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -9,7 +9,6 @@
 #define JSONXX_DEFINE_H
 
 #include <cstddef>
-#include <cassert>
 #include <iostream>
 #include <limits>
 #include <map>

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -9,6 +9,7 @@
 #define JSONXX_DEFINE_H
 
 #include <cstddef>
+#include <iostream>
 #include <limits>
 #include <map>
 #include <vector>
@@ -46,10 +47,6 @@
 #else
 #define JSONXX_WARN(...) ;
 #endif
-
-namespace std {
-    class iostream;
-}
 
 namespace jsonxx {
 

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -9,13 +9,11 @@
 #define JSONXX_DEFINE_H
 
 #include <cstddef>
-#include <iostream>
 #include <limits>
 #include <map>
 #include <vector>
 #include <string>
 #include <string_view>
-#include <sstream>
 
 // jsonxx versioning: major.minor-extra where
 // major = { number }
@@ -48,6 +46,10 @@
 #else
 #define JSONXX_WARN(...) ;
 #endif
+
+namespace std {
+    class iostream;
+}
 
 namespace jsonxx {
 


### PR DESCRIPTION
Quite insanely, we were polluting every files including `jsonxx.h` with `cassert` for no reasons. 